### PR TITLE
West init support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 This is a project that aims to port a balancing robot project written for the nRF52832 DK using the nRF5 SDK v13, to the nRF9160 DK using the nRF Connect SDK.
 
-## Project setup
-- Clone this project into any folder that has an [nRF Connect SDK installation](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/gs_assistant.html). I used ncs v1.9.0, but I think anything after v1.6.0 should work (pre-v1.6.0 has no support for the IMU, MPU9250).
+## Project setup (Using existing nRF Connect SDK installation)
+- Clone this project into any folder that has an [nRF Connect SDK v1.9.0 installation](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/gs_assistant.html). 
 - Build and flash the project as you would with any sample. Make sure that the physical switch `SW10` on the DK is set to the chip you want to flash to.
+
+## Project setup (New nRF Connect SDK installation)
+- Ensure all required software for building nRF Connect SDK v1.9.0 is installed. A list of required software and appropriate versions can be found at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.0/nrf/gs_recommended_versions.html.
+- Create project directory
+- Inside project directory, run command ```west init -m https://github.com/Embla-Flatlandsmo/nRF9160dk-balancing-robot.git```. This will download the project files, nRF Connect SDK v1.9.0, and their dependencies.
+- Navigate to folder containing firmware for the microcontroller you want to work with (```./balancing_robot_firmware/<MCU NAME>```) and use west commands for building and flashing the firmware as described in the [developer guide](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.0/zephyr/guides/west/build-flash-debug.html#west-build-flash-debug).
 
 ### nRF9160
 Implements most (all?) of the functionalities that was present in the nRF52832 sample. Except bluetooth, perhaps?

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This is a project that aims to port a balancing robot project written for the nR
 ## Project setup (New nRF Connect SDK installation)
 - Ensure all required software for building nRF Connect SDK v1.9.0 is installed. A list of required software and appropriate versions can be found at https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.0/nrf/gs_recommended_versions.html.
 - Create project directory
-- Inside project directory, run command ```west init -m https://github.com/Embla-Flatlandsmo/nRF9160dk-balancing-robot.git```. This will download the project files, nRF Connect SDK v1.9.0, and their dependencies.
+- Inside project directory, run command ```west init -m https://github.com/Embla-Flatlandsmo/nRF9160dk-balancing-robot.git```. This will set up the west configurations for the project directory.
+- In the same directory, run ```west update```. This will download the project files, nRF Connect SDK v1.9.0, and their dependencies.
 - Navigate to folder containing firmware for the microcontroller you want to work with (```./balancing_robot_firmware/<MCU NAME>```) and use west commands for building and flashing the firmware as described in the [developer guide](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.0/zephyr/guides/west/build-flash-debug.html#west-build-flash-debug).
 
 ### nRF9160

--- a/west.yml
+++ b/west.yml
@@ -12,8 +12,8 @@ manifest:
     - name: sdk-nrf
       remote: nrfconnect
       path: nrf
-      revision: v1.8.0 
+      revision: v1.9.0 
       import: true
       
   self:
-    path: balancing-robot-firmware
+    path: balancing_robot_firmware

--- a/west.yml
+++ b/west.yml
@@ -16,4 +16,4 @@ manifest:
       import: true
       
   self:
-    path: balancing-robot-shield-firmware
+    path: balancing-robot-firmware

--- a/west.yml
+++ b/west.yml
@@ -1,0 +1,19 @@
+manifest:
+  version: "0.10"
+
+  defaults:
+    revision: main
+
+  remotes:
+    - name: nrfconnect
+      url-base: https://github.com/nrfconnect/
+
+  projects:
+    - name: sdk-nrf
+      remote: nrfconnect
+      path: nrf
+      revision: v1.8.0 
+      import: true
+      
+  self:
+    path: balancing-robot-shield-firmware


### PR DESCRIPTION
Adds a west manifest to allow the use of ```west init```.